### PR TITLE
Add s3-compat Rust crate

### DIFF
--- a/s3-compat/Cargo.toml
+++ b/s3-compat/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "s3-compat"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+tokio = { version = "1", features = ["rt-multi-thread"] }
+hyper = "0.14"
+s3s = "0.1"
+aws-sigv4 = "1.3"
+quick-xml = "0.25"
+serde = { version = "1.0", features = ["derive"] }
+serde_bytes = "0.11"
+tracing = "0.1"
+async-trait = "0.1"

--- a/s3-compat/src/main.rs
+++ b/s3-compat/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Hello, world!");
+}


### PR DESCRIPTION
## Summary
- introduce a new `s3-compat` binary crate
- set Rust edition to 2021 and add required dependencies

## Testing
- `cargo check` *(fails: failed to download from crates.io due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_687b54cec1f083279eab39788f6439ec