### PR TITLE
Add stub S3 implementation

### DIFF
--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -17,4 +17,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.128"
 log4rs = "1.3.0"
 log-mdc = "0.1.0"
+async-trait = "0.1"
+hyper = "0.14"
+s3s = "0.1"
 

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -1,16 +1,39 @@
 use std::collections::HashMap;
+use std::sync::Mutex;
 
 /// Simple in-memory storage mapping bucket -> (key -> bytes).
 pub struct MyStorage {
-    map: HashMap<String, HashMap<String, Vec<u8>>>,
+    map: Mutex<HashMap<String, HashMap<String, Vec<u8>>>>,
 }
 
 impl MyStorage {
     /// Create an empty storage instance.
     pub fn new() -> Self {
         Self {
-            map: HashMap::new(),
+            map: Mutex::new(HashMap::new()),
         }
     }
 }
 
+use futures::stream;
+use hyper::body::Bytes;
+use s3s::dto::{
+    GetObjectOutput, GetObjectRequest, PutObjectOutput, PutObjectRequest, StreamingBlob,
+};
+use s3s::{S3Result, S3};
+
+#[async_trait::async_trait]
+impl S3 for MyStorage {
+    async fn get_object(&self, _input: GetObjectRequest) -> S3Result<GetObjectOutput> {
+        let body = StreamingBlob::wrap(stream::once(async {
+            Ok::<Bytes, std::io::Error>(Bytes::new())
+        }));
+        let mut out = GetObjectOutput::default();
+        out.body = Some(body);
+        Ok(out)
+    }
+
+    async fn put_object(&self, _input: PutObjectRequest) -> S3Result<PutObjectOutput> {
+        Ok(PutObjectOutput::default())
+    }
+}


### PR DESCRIPTION
## Summary
- update server dependencies to include s3s and async support
- implement the `s3s::S3` trait for `MyStorage`

## Testing
- `cargo check --manifest-path server/Cargo.toml`
- `cargo check --manifest-path s3-compat/Cargo.toml`

------
https://chatgpt.com/codex/tasks/task_e_687b5c9e5e9083278d124a2a1661491a