### PR TITLE
Implement tokio main for S3 compat server

### DIFF
--- a/s3-compat/Cargo.toml
+++ b/s3-compat/Cargo.toml
@@ -4,8 +4,8 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-tokio = { version = "1", features = ["rt-multi-thread"] }
-hyper = "0.14"
+tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
+hyper = { version = "0.14", features = ["full"] }
 s3s = "0.1"
 aws-sigv4 = "1.3"
 quick-xml = "0.25"
@@ -13,3 +13,4 @@ serde = { version = "1.0", features = ["derive"] }
 serde_bytes = "0.11"
 tracing = "0.1"
 async-trait = "0.1"
+CIAOS = { path = "../server" }

--- a/s3-compat/src/main.rs
+++ b/s3-compat/src/main.rs
@@ -1,3 +1,14 @@
-fn main() {
-    println!("Hello, world!");
+use hyper::{service::make_service_fn, Server};
+use CIAOS::MyStorage;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let svc = MyStorage::new();
+    let router = s3s::server::router(svc);
+    Server::bind(&([0, 0, 0, 0], 8000).into())
+        .serve(make_service_fn(|_| async {
+            Ok::<_, hyper::Error>(router.clone())
+        }))
+        .await?;
+    Ok(())
 }


### PR DESCRIPTION
## Summary
- add S3 compat server example using hyper and tokio
- enable necessary features in `s3-compat` crate and link to server crate

## Testing
- `cargo check` *(fails: could not find `server` in `s3s`)*

------
https://chatgpt.com/codex/tasks/task_e_687b8b8d212c83279328732b5f5a3be6